### PR TITLE
Implement manual card entry option

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,10 +7,15 @@ This repository contains a simple Python tool to simulate drawing cards from a s
 Run the simulator with Python 3:
 
 ```bash
-python3 highlow.py
+python3 highlow.py [--manual]
 ```
 
-Press Enter to draw a new card. After each draw, the script prints:
+By default the simulator draws random cards from the deck each time you press
+Enter. Use the `--manual` option to manually enter the sequence of cards as
+they are revealed.
+
+Press Enter (or provide ranks in manual mode) to draw a new card. After each
+draw, the script prints:
 
 - The card drawn
 - The number of cards left in the deck

--- a/highlow.py
+++ b/highlow.py
@@ -1,8 +1,17 @@
 import random
+import argparse
 from dataclasses import dataclass
 
 RANK_NAMES = {11: 'Jack', 12: 'Queen', 13: 'King', 14: 'Ace'}
 SUITS = ['hearts', 'diamonds', 'clubs', 'spades']
+RANK_LOOKUP = {
+    '2': 2, '3': 3, '4': 4, '5': 5, '6': 6, '7': 7, '8': 8,
+    '9': 9, '10': 10,
+    'j': 11, 'jack': 11,
+    'q': 12, 'queen': 12,
+    'k': 13, 'king': 13,
+    'a': 14, 'ace': 14,
+}
 
 @dataclass(frozen=True)
 class Card:
@@ -12,6 +21,14 @@ class Card:
     def __str__(self) -> str:
         name = RANK_NAMES.get(self.rank, str(self.rank))
         return f"{name} of {self.suit}"
+
+
+def parse_rank(value: str) -> int:
+    """Convert user input into a card rank number."""
+    key = value.strip().lower()
+    if key not in RANK_LOOKUP:
+        raise ValueError(f"Unknown card rank: {value}")
+    return RANK_LOOKUP[key]
 
 class Deck:
     """Represents a deck of playing cards."""
@@ -30,6 +47,14 @@ class Deck:
         self.played.append(card)
         return card
 
+    def remove_rank(self, rank: int) -> Card:
+        """Remove one card of the given rank from the deck."""
+        for i, card in enumerate(self.remaining):
+            if card.rank == rank:
+                self.played.append(self.remaining.pop(i))
+                return card
+        raise RuntimeError(f"No card of rank {rank} left in the deck")
+
     def probability_next(self, current: Card):
         """Return probability that next card is higher or lower than ``current``."""
         higher = sum(c.rank > current.rank for c in self.remaining)
@@ -43,7 +68,7 @@ class Deck:
         return p_high, p_low, suggestion
 
 
-def main() -> None:
+def automatic_game() -> None:
     deck = Deck()
     print("High-Low deck simulator. Press Enter to draw a card.")
     while deck.remaining:
@@ -58,6 +83,46 @@ def main() -> None:
             print(f"Suggested guess: {suggestion}")
         else:
             print("No cards left in the deck.")
+
+
+def manual_game() -> None:
+    deck = Deck()
+    print("Manual High-Low assistant. Type 'exit' to quit.")
+    while deck.remaining:
+        down = input("\nFirst card face down (rank): ").strip()
+        if not down or down.lower() in {"exit", "quit"}:
+            break
+        try:
+            rank = parse_rank(down)
+            deck.remove_rank(rank)
+        except Exception as exc:
+            print(exc)
+            continue
+        if deck.remaining:
+            p_high, p_low, suggestion = deck.probability_next(Card(rank, ''))
+            print(f"Probability next card is higher: {p_high:.2%}")
+            print(f"Probability next card is lower: {p_low:.2%}")
+            print(f"Suggested guess: {suggestion}")
+        reveal = input("Revealed card (rank): ").strip()
+        if not reveal:
+            break
+        try:
+            deck.remove_rank(parse_rank(reveal))
+        except Exception as exc:
+            print(exc)
+            continue
+        print(f"Cards left: {len(deck.remaining)}")
+    print("Game over.")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="High-Low card simulator")
+    parser.add_argument("--manual", action="store_true", help="Manually enter cards")
+    args = parser.parse_args()
+    if args.manual:
+        manual_game()
+    else:
+        automatic_game()
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
## Summary
- add optional manual mode to `highlow.py`
- support parsing card ranks from user input
- document the new `--manual` flag in README

## Testing
- `python3 highlow.py --help`
- `python3 highlow.py --manual <<'EOF'
exit
EOF`
- `python3 highlow.py <<'EOF'


EOF` *(fails: EOF when reading a line)*

------
https://chatgpt.com/codex/tasks/task_e_686c8ddcbfd8832982620ef81bbd8941